### PR TITLE
Update API key path

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -18,7 +18,7 @@ Conditions:
 Parameters:
   DdApiKey:
     Type: String
-    Description: The Datadog API key, which can be found from the APIs page (/account/settings#api).
+    Description: The Datadog API key, which can be found from the APIs page (/organization-settings/api-keys).
     NoEcho: true
   DdSite:
     Type: String


### PR DESCRIPTION
Previous API path was not working.  Is this one correct now for all users?

