### PR TITLE
Update template version's string format to avoid those values to be changed by publish script

### DIFF
--- a/step-function-demo-app/publish.sh
+++ b/step-function-demo-app/publish.sh
@@ -65,10 +65,10 @@ echo "Validating template.yaml..."
 aws-login aws cloudformation validate-template --template-body file://dist/template.yaml
 echo "Uploading the CloudFormation Template"
 if [ "$ACCOUNT" = "prod" ]; then
-    # Make sure we are on the master branch
+    # Make sure we are on the main branch
     BRANCH=$(git rev-parse --abbrev-ref HEAD)
     if [ $BRANCH != "main" ]; then
-        echo "ERROR: Not on the master branch, aborting."
+        echo "ERROR: Not on the main branch, aborting."
         exit 1
     fi
 
@@ -83,7 +83,7 @@ if [ "$ACCOUNT" = "prod" ]; then
     # Get the latest code
     git pull origin main
 
-    # Bump version number in settings.py and template.yml
+    # Bump version number in template.yml
     echo "Bumping the version number to ${SAMPLE_APP_VERSION}..."
     perl -pi -e "s/Version: [0-9\.]+/Version: ${SAMPLE_APP_VERSION}/g" template.yaml
     perl -pi -e "s/Version: [0-9\.]+/Version: ${SAMPLE_APP_VERSION}/g" dist/template.yaml

--- a/step-function-demo-app/template.yaml
+++ b/step-function-demo-app/template.yaml
@@ -5,7 +5,7 @@ Description: >
 
 Mappings:
   Constants:
-    DatadogServerlessSampleApp:
+    DatadogStepFunctionsTracingDemoApp:
       Version: 0.1.0
 
 Parameters:
@@ -136,7 +136,7 @@ Resources:
     Type: 'AWS::IAM::Role'
     Properties:
       AssumeRolePolicyDocument:
-        Version: 2012-10-17
+        Version: "2012-10-17"
         Statement:
           - Effect: Allow
             Principal:
@@ -146,7 +146,7 @@ Resources:
       Policies:
         - PolicyName: root
           PolicyDocument:
-            Version: 2012-10-17
+            Version: "2012-10-17"
             Statement:
             - Effect: Allow
               Action:
@@ -158,7 +158,7 @@ Resources:
     Properties:
       Path: "/"
       AssumeRolePolicyDocument:
-        Version: 2012-10-17
+        Version: "2012-10-17"
         Statement:
           - Effect: Allow
             Principal:
@@ -167,7 +167,7 @@ Resources:
       Policies:
       - PolicyName: root
         PolicyDocument:
-          Version: 2012-10-17
+          Version: "2012-10-17"
           Statement:
           - Effect: Allow
             Action:
@@ -175,7 +175,7 @@ Resources:
             Resource: arn:aws:logs:*:*:*
       - PolicyName: ddbQuery
         PolicyDocument:
-          Version: 2012-10-17
+          Version: "2012-10-17"
           Statement:
           - Effect: Allow
             Action:
@@ -186,7 +186,7 @@ Resources:
     Type: 'AWS::IAM::Role'
     Properties:
       AssumeRolePolicyDocument:
-        Version: 2012-10-17
+        Version: "2012-10-17"
         Statement:
           - Effect: Allow
             Principal:
@@ -197,7 +197,7 @@ Resources:
       Policies:
         - PolicyName: root
           PolicyDocument:
-            Version: 2012-10-17
+            Version: "2012-10-17"
             Statement:
             - Effect: Allow
               Action:
@@ -205,7 +205,7 @@ Resources:
               Resource: '*'
         - PolicyName: StatesExecutionPolicy
           PolicyDocument:
-            Version: 2012-10-17
+            Version: "2012-10-17"
             Statement:
               - Effect: Allow
                 Action:
@@ -213,7 +213,7 @@ Resources:
                 Resource: '*'
         - PolicyName: DynamodbPolicy
           PolicyDocument:
-            Version: 2012-10-17
+            Version: "2012-10-17"
             Statement:
               - Effect: Allow
                 Action:

--- a/step-function-demo-app/template.yaml
+++ b/step-function-demo-app/template.yaml
@@ -1,4 +1,4 @@
-AWSTemplateFormatVersion: 2010-09-09
+AWSTemplateFormatVersion: "2010-09-09"
 
 Description: >
   Datadog Step Functions Tracing Demo App
@@ -6,7 +6,7 @@ Description: >
 Mappings:
   Constants:
     DatadogStepFunctionsTracingDemoApp:
-      Version: 0.1.0
+      Version: 0.1.1
 
 Parameters:
   DdApiKey:

--- a/step-function-demo-app/template.yaml
+++ b/step-function-demo-app/template.yaml
@@ -1,4 +1,4 @@
-AWSTemplateFormatVersion: 0.1.1-09-09
+AWSTemplateFormatVersion: 2010-09-09
 
 Description: >
   Datadog Step Functions Tracing Demo App
@@ -6,7 +6,7 @@ Description: >
 Mappings:
   Constants:
     DatadogServerlessSampleApp:
-      Version: 0.1.1
+      Version: 0.1.0
 
 Parameters:
   DdApiKey:
@@ -136,7 +136,7 @@ Resources:
     Type: 'AWS::IAM::Role'
     Properties:
       AssumeRolePolicyDocument:
-        Version: 0.1.1-10-17
+        Version: 2012-10-17
         Statement:
           - Effect: Allow
             Principal:
@@ -146,7 +146,7 @@ Resources:
       Policies:
         - PolicyName: root
           PolicyDocument:
-            Version: 0.1.1-10-17
+            Version: 2012-10-17
             Statement:
             - Effect: Allow
               Action:
@@ -158,7 +158,7 @@ Resources:
     Properties:
       Path: "/"
       AssumeRolePolicyDocument:
-        Version: 0.1.1-10-17
+        Version: 2012-10-17
         Statement:
           - Effect: Allow
             Principal:
@@ -167,7 +167,7 @@ Resources:
       Policies:
       - PolicyName: root
         PolicyDocument:
-          Version: 0.1.1-10-17
+          Version: 2012-10-17
           Statement:
           - Effect: Allow
             Action:
@@ -175,7 +175,7 @@ Resources:
             Resource: arn:aws:logs:*:*:*
       - PolicyName: ddbQuery
         PolicyDocument:
-          Version: 0.1.1-10-17
+          Version: 2012-10-17
           Statement:
           - Effect: Allow
             Action:
@@ -186,7 +186,7 @@ Resources:
     Type: 'AWS::IAM::Role'
     Properties:
       AssumeRolePolicyDocument:
-        Version: 0.1.1-10-17
+        Version: 2012-10-17
         Statement:
           - Effect: Allow
             Principal:
@@ -197,7 +197,7 @@ Resources:
       Policies:
         - PolicyName: root
           PolicyDocument:
-            Version: 0.1.1-10-17
+            Version: 2012-10-17
             Statement:
             - Effect: Allow
               Action:
@@ -205,7 +205,7 @@ Resources:
               Resource: '*'
         - PolicyName: StatesExecutionPolicy
           PolicyDocument:
-            Version: 0.1.1-10-17
+            Version: 2012-10-17
             Statement:
               - Effect: Allow
                 Action:
@@ -213,7 +213,7 @@ Resources:
                 Resource: '*'
         - PolicyName: DynamodbPolicy
           PolicyDocument:
-            Version: 0.1.1-10-17
+            Version: 2012-10-17
             Statement:
               - Effect: Allow
                 Action:


### PR DESCRIPTION
This PR first reverted the previous commit and then fixes the bug that may be caused by the script.

The `publish_script.sh` searches for "version:" and replace the older version with the new version. To avoid changing the IAM role policy version, adding double quotes to all version values that does not indent to be changed by the script.