### PR TITLE
Remove Step Functions `dd_` tags prefix from demo state machine

### DIFF
--- a/step-function-demo-app/template.yaml
+++ b/step-function-demo-app/template.yaml
@@ -117,10 +117,10 @@ Resources:
           Key: "env"
           Value: "dev"
         -
-          Key: "dd_service"
-          Value: "demo-dd-service"
+          Key: "service"
+          Value: "datadog-demo-service"
         -
-          Key: "dd_version"
+          Key: "version"
           Value: "1"
       DefinitionString: !Sub
         - |-


### PR DESCRIPTION
We perfer `service` and `version` over the ones with `dd_` prefix.