### PR TITLE
Update versions for layers and runtimes for serverless-sample-app

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -73,8 +73,8 @@ Resources:
       Handler: datadog_lambda.handler.handler
       MemorySize: 512
       Layers:
-        - !Sub arn:aws:lambda:${AWS::Region}:464622532012:layer:Datadog-Extension:36
-        - !Sub arn:aws:lambda:${AWS::Region}:464622532012:layer:Datadog-Python39:67
+        - !Sub arn:aws:lambda:${AWS::Region}:464622532012:layer:Datadog-Extension:44
+        - !Sub arn:aws:lambda:${AWS::Region}:464622532012:layer:Datadog-Python39:73
       Environment:
         Variables:
           DD_LAMBDA_HANDLER: index.handler
@@ -125,12 +125,12 @@ Resources:
       Handler: "/opt/nodejs/node_modules/datadog-lambda-js/handler.handler"
       MemorySize: 512
       Layers:
-        - !Sub arn:aws:lambda:${AWS::Region}:464622532012:layer:Datadog-Extension:21
-        - !Sub arn:aws:lambda:${AWS::Region}:464622532012:layer:Datadog-Node12-x:73
+        - !Sub arn:aws:lambda:${AWS::Region}:464622532012:layer:Datadog-Extension:44
+        - !Sub arn:aws:lambda:${AWS::Region}:464622532012:layer:Datadog-Node18-x:91
       Code:
         ZipFile: |
           INJECT_SQS_CONSUMER_CODE_PLACEHOLDER
-      Runtime: nodejs12.x
+      Runtime: nodejs18.x
       Environment:
         Variables:
           DD_LAMBDA_HANDLER: index.handler


### PR DESCRIPTION
### What does this PR do?

In the template.yml:
- Updates Extension versions to 44 (latest)
- Updates Python (v73) and Node (v91) to latest
- Updates node runtime to 18 from 12 (deprecated)

### Motivation

- Reported by support
- We have a link to this sample app in some of our onboarding pages, we should update/get rid of deprecated runtimes.

### Testing Guidelines

- Deploy the sample app using the modified template.yml
- Check latest versions for Node layer here https://docs.datadoghq.com/serverless/installation/nodejs/?tab=custom
- Check latest versions for Python layer here https://docs.datadoghq.com/serverless/installation/python/?tab=custom
- Check heading "Supported Runtimes" on AWS docs https://docs.aws.amazon.com/lambda/latest/dg/lambda-runtimes.html
- 16 and 14 will be deprecated soon so might as well get on Node 18

### Types of Changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [x] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
