### PR TITLE
chore: update Datadog layer to `v66`

### DIFF
--- a/src/dotnet/README.md
+++ b/src/dotnet/README.md
@@ -17,8 +17,8 @@ You also need to ensure you manually add the Datadog Lambda layers, one for the 
 ```c#
 Layers =
 [
-    LayerVersion.FromLayerVersionArn(this, "DDExtension", "arn:aws:lambda:eu-west-1:464622532012:layer:Datadog-Extension-ARM:65"),
-    LayerVersion.FromLayerVersionArn(this, "DDTrace", "arn:aws:lambda:eu-west-1:464622532012:layer:dd-trace-dotnet-ARM:15"),
+    LayerVersion.FromLayerVersionArn(this, "DDExtension", "arn:aws:lambda:eu-west-1:464622532012:layer:Datadog-Extension-ARM:66"),
+    LayerVersion.FromLayerVersionArn(this, "DDTrace", "arn:aws:lambda:eu-west-1:464622532012:layer:dd-trace-dotnet-ARM:16"),
 ],
 ```
 
@@ -142,8 +142,8 @@ module "aws_lambda_function" {
     var.environment_variables
   )
 
-  datadog_extension_layer_version = 65
-  datadog_dotnet_layer_version      = 15
+  datadog_extension_layer_version = 66
+  datadog_dotnet_layer_version      = 16
 }
 ```
 

--- a/src/dotnet/cdk/Constructs/InstrumentedFunction.cs
+++ b/src/dotnet/cdk/Constructs/InstrumentedFunction.cs
@@ -60,8 +60,8 @@ public class InstrumentedFunction : Construct
                 LogRetention = RetentionDays.ONE_DAY,
                 Layers =
                 [
-                    LayerVersion.FromLayerVersionArn(this, "DDExtension", "arn:aws:lambda:eu-west-1:464622532012:layer:Datadog-Extension-ARM:65"),
-                    LayerVersion.FromLayerVersionArn(this, "DDTrace", "arn:aws:lambda:eu-west-1:464622532012:layer:dd-trace-dotnet-ARM:15"),
+                    LayerVersion.FromLayerVersionArn(this, "DDExtension", "arn:aws:lambda:eu-west-1:464622532012:layer:Datadog-Extension-ARM:66"),
+                    LayerVersion.FromLayerVersionArn(this, "DDTrace", "arn:aws:lambda:eu-west-1:464622532012:layer:dd-trace-dotnet-ARM:16"),
                 ],
             });
 

--- a/src/dotnet/infra/modules/lambda-function/main.tf
+++ b/src/dotnet/infra/modules/lambda-function/main.tf
@@ -103,6 +103,6 @@ module "aws_lambda_function" {
     var.environment_variables
   )
 
-  datadog_extension_layer_version = 65
-  datadog_dotnet_layer_version      = 15
+  datadog_extension_layer_version = 66
+  datadog_dotnet_layer_version      = 16
 }

--- a/src/dotnet/template-analytics-service.yaml
+++ b/src/dotnet/template-analytics-service.yaml
@@ -12,8 +12,8 @@ Transform:
     Parameters:
       stackName: !Ref "AWS::StackName"
       apiKeySecretArn: !Ref DDApiKeySecretArn
-      dotnetLayerVersion: "15"
-      extensionLayerVersion: "65"
+      dotnetLayerVersion: "16"
+      extensionLayerVersion: "66"
       service: !Ref ServiceName
       env: !Ref Env
       version: !Ref CommitHash
@@ -45,6 +45,7 @@ Globals:
       Variables:
         ENV: !Ref Env
         DD_LOGS_INJECTION: "true"
+        DD_EXTENSION_VERSION: next
         POWERTOOLS_SERVICE_NAME: !Ref ServiceName
         POWERTOOLS_LOG_LEVEL: 'INFO'
         AWS_LAMBDA_EXEC_WRAPPER: /opt/datadog_wrapper

--- a/src/dotnet/template-api.yaml
+++ b/src/dotnet/template-api.yaml
@@ -12,8 +12,8 @@ Transform:
     Parameters:
       stackName: !Ref "AWS::StackName"
       apiKeySecretArn: !Ref DDApiKeySecretArn
-      dotnetLayerVersion: "15"
-      extensionLayerVersion: "65"
+      dotnetLayerVersion: "16"
+      extensionLayerVersion: "66"
       service: !Ref ServiceName
       env: !Ref Env
       version: !Ref CommitHash
@@ -45,6 +45,7 @@ Globals:
       Variables:
         ENV: !Ref Env
         DD_LOGS_INJECTION: "true"
+        DD_EXTENSION_VERSION: next
         TABLE_NAME: !Ref ProductApiTable
         POWERTOOLS_SERVICE_NAME: !Ref ServiceName
         POWERTOOLS_LOG_LEVEL: 'INFO'

--- a/src/dotnet/template-inventory-acl.yaml
+++ b/src/dotnet/template-inventory-acl.yaml
@@ -12,8 +12,8 @@ Transform:
     Parameters:
       stackName: !Ref "AWS::StackName"
       apiKeySecretArn: !Ref DDApiKeySecretArn
-      dotnetLayerVersion: "15"
-      extensionLayerVersion: "65"
+      dotnetLayerVersion: "16"
+      extensionLayerVersion: "66"
       service: !Ref ServiceName
       env: !Ref Env
       version: !Ref CommitHash
@@ -45,6 +45,7 @@ Globals:
       Variables:
         ENV: !Ref Env
         DD_LOGS_INJECTION: "true"
+        DD_EXTENSION_VERSION: next
         POWERTOOLS_SERVICE_NAME: !Ref ServiceName
         POWERTOOLS_LOG_LEVEL: 'INFO'
         AWS_LAMBDA_EXEC_WRAPPER: /opt/datadog_wrapper

--- a/src/dotnet/template-inventory-ordering-service.yaml
+++ b/src/dotnet/template-inventory-ordering-service.yaml
@@ -12,8 +12,8 @@ Transform:
     Parameters:
       stackName: !Ref "AWS::StackName"
       apiKeySecretArn: !Ref DDApiKeySecretArn
-      dotnetLayerVersion: "15"
-      extensionLayerVersion: "65"
+      dotnetLayerVersion: "16"
+      extensionLayerVersion: "66"
       service: !Ref ServiceName
       env: !Ref Env
       version: !Ref CommitHash
@@ -48,6 +48,7 @@ Globals:
       Variables:
         ENV: !Ref Env
         DD_LOGS_INJECTION: "true"
+        DD_EXTENSION_VERSION: next
         POWERTOOLS_SERVICE_NAME: !Ref ServiceName
         POWERTOOLS_LOG_LEVEL: 'INFO'
         AWS_LAMBDA_EXEC_WRAPPER: /opt/datadog_wrapper

--- a/src/dotnet/template-pricing-service.yaml
+++ b/src/dotnet/template-pricing-service.yaml
@@ -12,8 +12,8 @@ Transform:
     Parameters:
       stackName: !Ref "AWS::StackName"
       apiKeySecretArn: !Ref DDApiKeySecretArn
-      extensionLayerVersion: "65"
-      dotnetLayerVersion: "15"
+      extensionLayerVersion: "66"
+      dotnetLayerVersion: "16"
       service: !Ref ServiceName
       env: !Ref Env
       version: !Ref CommitHash
@@ -45,6 +45,7 @@ Globals:
       Variables:
         ENV: !Ref Env
         DD_LOGS_INJECTION: "true"
+        DD_EXTENSION_VERSION: next
         POWERTOOLS_SERVICE_NAME: !Ref ServiceName
         POWERTOOLS_LOG_LEVEL: 'INFO'
         AWS_LAMBDA_EXEC_WRAPPER: /opt/datadog_wrapper

--- a/src/dotnet/template-product-api-worker.yaml
+++ b/src/dotnet/template-product-api-worker.yaml
@@ -12,8 +12,8 @@ Transform:
     Parameters:
       stackName: !Ref "AWS::StackName"
       apiKeySecretArn: !Ref DDApiKeySecretArn
-      extensionLayerVersion: "65"
-      dotnetLayerVersion: "15"
+      extensionLayerVersion: "66"
+      dotnetLayerVersion: "16"
       service: !Ref ServiceName
       env: !Ref Env
       version: !Ref CommitHash
@@ -48,6 +48,7 @@ Globals:
       Variables:
         ENV: !Ref Env
         DD_LOGS_INJECTION: "true"
+        DD_EXTENSION_VERSION: next
         POWERTOOLS_SERVICE_NAME: !Ref ServiceName
         POWERTOOLS_LOG_LEVEL: 'INFO'
         AWS_LAMBDA_EXEC_WRAPPER: /opt/datadog_wrapper

--- a/src/dotnet/template-product-event-publisher.yaml
+++ b/src/dotnet/template-product-event-publisher.yaml
@@ -12,8 +12,8 @@ Transform:
     Parameters:
       stackName: !Ref "AWS::StackName"
       apiKeySecretArn: !Ref DDApiKeySecretArn
-      extensionLayerVersion: "65"
-      dotnetLayerVersion: "15"
+      extensionLayerVersion: "66"
+      dotnetLayerVersion: "16"
       service: !Ref ServiceName
       env: !Ref Env
       version: !Ref CommitHash
@@ -45,6 +45,7 @@ Globals:
       Variables:
         ENV: !Ref Env
         DD_LOGS_INJECTION: "true"
+        DD_EXTENSION_VERSION: next
         POWERTOOLS_SERVICE_NAME: !Ref ServiceName
         POWERTOOLS_LOG_LEVEL: 'INFO'
         AWS_LAMBDA_EXEC_WRAPPER: /opt/datadog_wrapper

--- a/src/go/README.md
+++ b/src/go/README.md
@@ -25,7 +25,7 @@ datadog := ddcdkconstruct.NewDatadog(
 		stack,
 		jsii.String("Datadog"),
 		&ddcdkconstruct.DatadogProps{
-			ExtensionLayerVersion:  jsii.Number(65),
+			ExtensionLayerVersion:  jsii.Number(66),
 			AddLayers:              jsii.Bool(true),
 			Site:                   jsii.String(os.Getenv("DD_SITE")),
 			ApiKeySecret:           ddApiKeySecret,

--- a/src/go/README.md
+++ b/src/go/README.md
@@ -90,7 +90,7 @@ The AWS SAM & Go Instrumentation works by manually adding the Datadog extension 
 Globals:
   Function:
     Layers:
-      - !Sub arn:aws:lambda:${AWS::Region}:464622532012:layer:Datadog-Extension-ARM:65
+      - !Sub arn:aws:lambda:${AWS::Region}:464622532012:layer:Datadog-Extension-ARM:66
     Environment:
       Variables:
         DD_ENV: !Ref Env
@@ -163,7 +163,7 @@ module "aws_lambda_function" {
     var.environment_variables
   )
 
-  datadog_extension_layer_version = 65
+  datadog_extension_layer_version = 66
 }
 ```
 

--- a/src/go/cdk/analytics-service/analyticsServiceStack.go
+++ b/src/go/cdk/analytics-service/analyticsServiceStack.go
@@ -48,7 +48,7 @@ func NewAnalyticsServiceStack(scope constructs.Construct, id string, props *Anal
 		stack,
 		jsii.String("Datadog"),
 		&ddcdkconstruct.DatadogProps{
-			ExtensionLayerVersion:  jsii.Number(65),
+			ExtensionLayerVersion:  jsii.Number(66),
 			AddLayers:              jsii.Bool(true),
 			Site:                   jsii.String(os.Getenv("DD_SITE")),
 			ApiKeySecret:           ddApiKeySecret,

--- a/src/go/cdk/inventory-ordering-service/inventoryOrderingServiceStack.go
+++ b/src/go/cdk/inventory-ordering-service/inventoryOrderingServiceStack.go
@@ -48,7 +48,7 @@ func NewInventoryOrderingServiceStack(scope constructs.Construct, id string, pro
 		stack,
 		jsii.String("Datadog"),
 		&ddcdkconstruct.DatadogProps{
-			ExtensionLayerVersion:  jsii.Number(65),
+			ExtensionLayerVersion:  jsii.Number(66),
 			AddLayers:              jsii.Bool(true),
 			Site:                   jsii.String(os.Getenv("DD_SITE")),
 			ApiKeySecret:           ddApiKeySecret,

--- a/src/go/cdk/inventoryAcl/inventoryAclServiceStack.go
+++ b/src/go/cdk/inventoryAcl/inventoryAclServiceStack.go
@@ -48,7 +48,7 @@ func NewInventoryAclStack(scope constructs.Construct, id string, props *Inventor
 		stack,
 		jsii.String("Datadog"),
 		&ddcdkconstruct.DatadogProps{
-			ExtensionLayerVersion:  jsii.Number(65),
+			ExtensionLayerVersion:  jsii.Number(66),
 			AddLayers:              jsii.Bool(true),
 			Site:                   jsii.String(os.Getenv("DD_SITE")),
 			ApiKeySecret:           ddApiKeySecret,

--- a/src/go/cdk/productApi/productApiStack.go
+++ b/src/go/cdk/productApi/productApiStack.go
@@ -46,7 +46,7 @@ func NewProductApiStack(scope constructs.Construct, id string, props *ProductApi
 		stack,
 		jsii.String("Datadog"),
 		&ddcdkconstruct.DatadogProps{
-			ExtensionLayerVersion:  jsii.Number(65),
+			ExtensionLayerVersion:  jsii.Number(66),
 			AddLayers:              jsii.Bool(true),
 			Site:                   jsii.String(os.Getenv("DD_SITE")),
 			ApiKeySecret:           ddApiKeySecret,

--- a/src/go/cdk/productApiWorker/productApiWorkerStack.go
+++ b/src/go/cdk/productApiWorker/productApiWorkerStack.go
@@ -49,7 +49,7 @@ func NewProductApiWorkerStack(scope constructs.Construct, id string, props *Prod
 		stack,
 		jsii.String("Datadog"),
 		&ddcdkconstruct.DatadogProps{
-			ExtensionLayerVersion:  jsii.Number(65),
+			ExtensionLayerVersion:  jsii.Number(66),
 			AddLayers:              jsii.Bool(true),
 			Site:                   jsii.String(os.Getenv("DD_SITE")),
 			ApiKeySecret:           ddApiKeySecret,

--- a/src/go/cdk/productPricingService/productPricingServiceStack.go
+++ b/src/go/cdk/productPricingService/productPricingServiceStack.go
@@ -48,7 +48,7 @@ func NewProductPricingServiceStack(scope constructs.Construct, id string, props 
 		stack,
 		jsii.String("Datadog"),
 		&ddcdkconstruct.DatadogProps{
-			ExtensionLayerVersion:  jsii.Number(65),
+			ExtensionLayerVersion:  jsii.Number(66),
 			AddLayers:              jsii.Bool(true),
 			Site:                   jsii.String(os.Getenv("DD_SITE")),
 			ApiKeySecret:           ddApiKeySecret,

--- a/src/go/cdk/productPublicEventPublisher/productPublicEventPublisherStack.go
+++ b/src/go/cdk/productPublicEventPublisher/productPublicEventPublisherStack.go
@@ -49,7 +49,7 @@ func NewProductPublicEventPublisherStack(scope constructs.Construct, id string, 
 		stack,
 		jsii.String("Datadog"),
 		&ddcdkconstruct.DatadogProps{
-			ExtensionLayerVersion:  jsii.Number(65),
+			ExtensionLayerVersion:  jsii.Number(66),
 			AddLayers:              jsii.Bool(true),
 			Site:                   jsii.String(os.Getenv("DD_SITE")),
 			ApiKeySecret:           ddApiKeySecret,

--- a/src/go/infra/modules/lambda-function/main.tf
+++ b/src/go/infra/modules/lambda-function/main.tf
@@ -102,5 +102,5 @@ module "aws_lambda_function" {
     var.environment_variables
   )
 
-  datadog_extension_layer_version = 65
+  datadog_extension_layer_version = 66
 }

--- a/src/go/template-analytics-service.yaml
+++ b/src/go/template-analytics-service.yaml
@@ -31,7 +31,7 @@ Globals:
     Timeout: 29
     MemorySize: 512
     Layers:
-      - !Sub arn:aws:lambda:${AWS::Region}:464622532012:layer:Datadog-Extension-ARM:65
+      - !Sub arn:aws:lambda:${AWS::Region}:464622532012:layer:Datadog-Extension-ARM:66
     Environment:
       Variables:
         ENV: !Ref Env

--- a/src/go/template-api.yaml
+++ b/src/go/template-api.yaml
@@ -32,7 +32,7 @@ Globals:
     Timeout: 29
     MemorySize: 512
     Layers:
-      - !Sub arn:aws:lambda:${AWS::Region}:464622532012:layer:Datadog-Extension-ARM:65
+      - !Sub arn:aws:lambda:${AWS::Region}:464622532012:layer:Datadog-Extension-ARM:66
     Environment:
       Variables:
         ENV: !Ref Env

--- a/src/go/template-inventory-acl.yaml
+++ b/src/go/template-inventory-acl.yaml
@@ -31,7 +31,7 @@ Globals:
     Timeout: 29
     MemorySize: 512
     Layers:
-      - !Sub arn:aws:lambda:${AWS::Region}:464622532012:layer:Datadog-Extension-ARM:65
+      - !Sub arn:aws:lambda:${AWS::Region}:464622532012:layer:Datadog-Extension-ARM:66
     Environment:
       Variables:
         ENV: !Ref Env

--- a/src/go/template-inventory-ordering-service.yaml
+++ b/src/go/template-inventory-ordering-service.yaml
@@ -34,7 +34,7 @@ Globals:
     Timeout: 29
     MemorySize: 512
     Layers:
-      - !Sub arn:aws:lambda:${AWS::Region}:464622532012:layer:Datadog-Extension-ARM:65
+      - !Sub arn:aws:lambda:${AWS::Region}:464622532012:layer:Datadog-Extension-ARM:66
     Environment:
       Variables:
         ENV: !Ref Env

--- a/src/go/template-pricing-service.yaml
+++ b/src/go/template-pricing-service.yaml
@@ -31,7 +31,7 @@ Globals:
     Timeout: 29
     MemorySize: 512
     Layers:
-      - !Sub arn:aws:lambda:${AWS::Region}:464622532012:layer:Datadog-Extension-ARM:65
+      - !Sub arn:aws:lambda:${AWS::Region}:464622532012:layer:Datadog-Extension-ARM:66
     Environment:
       Variables:
         ENV: !Ref Env

--- a/src/go/template-product-api-worker.yaml
+++ b/src/go/template-product-api-worker.yaml
@@ -34,7 +34,7 @@ Globals:
     Timeout: 29
     MemorySize: 512
     Layers:
-      - !Sub arn:aws:lambda:${AWS::Region}:464622532012:layer:Datadog-Extension-ARM:65
+      - !Sub arn:aws:lambda:${AWS::Region}:464622532012:layer:Datadog-Extension-ARM:66
     Environment:
       Variables:
         ENV: !Ref Env

--- a/src/go/template-product-event-publisher.yaml
+++ b/src/go/template-product-event-publisher.yaml
@@ -31,7 +31,7 @@ Globals:
     Timeout: 29
     MemorySize: 512
     Layers:
-      - !Sub arn:aws:lambda:${AWS::Region}:464622532012:layer:Datadog-Extension-ARM:65
+      - !Sub arn:aws:lambda:${AWS::Region}:464622532012:layer:Datadog-Extension-ARM:66
     Environment:
       Variables:
         ENV: !Ref Env

--- a/src/java/README.md
+++ b/src/java/README.md
@@ -15,7 +15,7 @@ When using Java as your language of choice with the AWS CDK, you need to manuall
 ```java
 List<ILayerVersion> layers = new ArrayList<>(2);
 layers.add(LayerVersion.fromLayerVersionArn(this, "DatadogJavaLayer", "arn:aws:lambda:eu-west-1:464622532012:layer:dd-trace-java:15"));
-layers.add(LayerVersion.fromLayerVersionArn(this, "DatadogLambdaExtension", "arn:aws:lambda:eu-west-1:464622532012:layer:Datadog-Extension:65"));
+layers.add(LayerVersion.fromLayerVersionArn(this, "DatadogLambdaExtension", "arn:aws:lambda:eu-west-1:464622532012:layer:Datadog-Extension:66"));
 
 var builder = Function.Builder.create(this, props.routingExpression())
     // Remove for brevity
@@ -152,7 +152,7 @@ module "aws_lambda_function" {
     var.environment_variables
   )
 
-  datadog_extension_layer_version = 65
+  datadog_extension_layer_version = 66
   datadog_java_layer_version      = 15
 }
 ```
@@ -226,7 +226,7 @@ custom:
     site: ${param:DD_SITE}
     env: ${sls:stage}
     service: ${self:custom.serviceName}
-    version: 65
+    version: 66
     # Use this property with care in production to ensure PII/Sensitive data is not stored in Datadog
     captureLambdaPayload: true
     propagateUpstreamTrace: true

--- a/src/java/cdk/src/main/java/com/cdk/constructs/InstrumentedFunction.java
+++ b/src/java/cdk/src/main/java/com/cdk/constructs/InstrumentedFunction.java
@@ -51,7 +51,7 @@ public class InstrumentedFunction extends Construct {
 
         List<ILayerVersion> layers = new ArrayList<>(2);
         layers.add(LayerVersion.fromLayerVersionArn(this, "DatadogJavaLayer", "arn:aws:lambda:eu-west-1:464622532012:layer:dd-trace-java:15"));
-        layers.add(LayerVersion.fromLayerVersionArn(this, "DatadogLambdaExtension", "arn:aws:lambda:eu-west-1:464622532012:layer:Datadog-Extension:65"));
+        layers.add(LayerVersion.fromLayerVersionArn(this, "DatadogLambdaExtension", "arn:aws:lambda:eu-west-1:464622532012:layer:Datadog-Extension:66"));
 
         IBucket bucket = Bucket.fromBucketName(this, "CDKBucket", fileAsset.getS3BucketName());
 

--- a/src/java/infra/modules/lambda-function/main.tf
+++ b/src/java/infra/modules/lambda-function/main.tf
@@ -106,7 +106,7 @@ module "aws_lambda_function" {
     var.environment_variables
   )
 
-  datadog_extension_layer_version = 65
+  datadog_extension_layer_version = 66
   datadog_java_layer_version      = 15
 }
 

--- a/src/java/serverless-analytics-service.yml
+++ b/src/java/serverless-analytics-service.yml
@@ -18,7 +18,7 @@ custom:
     site: ${param:DD_SITE}
     env: ${sls:stage}
     service: ${self:custom.serviceName}
-    version: 65
+    version: 66
     # Use this property with care in production to ensure PII/Sensitive data is not stored in Datadog
     captureLambdaPayload: true
     propagateUpstreamTrace: true 

--- a/src/java/template-analytics-service.yaml
+++ b/src/java/template-analytics-service.yaml
@@ -13,7 +13,7 @@ Transform:
       stackName: !Ref "AWS::StackName"
       apiKeySecretArn: !Ref DDApiKeySecretArn
       javaLayerVersion: "15"
-      extensionLayerVersion: "65"
+      extensionLayerVersion: "66"
       service: !Ref ServiceName
       env: !Ref Env
       version: !Ref CommitHash
@@ -45,6 +45,7 @@ Globals:
       Variables:
         ENV: !Ref Env
         DD_LOGS_INJECTION: "true"
+        DD_EXTENSION_VERSION: next
         POWERTOOLS_SERVICE_NAME: !Ref ServiceName
         POWERTOOLS_LOG_LEVEL: 'INFO'
         MAIN_CLASS: com.analytics.FunctionConfiguration

--- a/src/java/template-api.yaml
+++ b/src/java/template-api.yaml
@@ -13,7 +13,7 @@ Transform:
       stackName: !Ref "AWS::StackName"
       apiKeySecretArn: !Ref DDApiKeySecretArn
       javaLayerVersion: "15"
-      extensionLayerVersion: "65"
+      extensionLayerVersion: "66"
       service: !Ref ServiceName
       env: !Ref Env
       version: !Ref CommitHash
@@ -45,6 +45,7 @@ Globals:
       Variables:
         ENV: !Ref Env
         DD_LOGS_INJECTION: "true"
+        DD_EXTENSION_VERSION: next
         TABLE_NAME: !Ref ProductApiTable
         POWERTOOLS_SERVICE_NAME: !Ref ServiceName
         POWERTOOLS_LOG_LEVEL: 'INFO'

--- a/src/java/template-inventory-acl.yaml
+++ b/src/java/template-inventory-acl.yaml
@@ -13,7 +13,7 @@ Transform:
       stackName: !Ref "AWS::StackName"
       apiKeySecretArn: !Ref DDApiKeySecretArn
       javaLayerVersion: "15"
-      extensionLayerVersion: "65"
+      extensionLayerVersion: "66"
       service: !Ref ServiceName
       env: !Ref Env
       version: !Ref CommitHash
@@ -45,6 +45,7 @@ Globals:
       Variables:
         ENV: !Ref Env
         DD_LOGS_INJECTION: "true"
+        DD_EXTENSION_VERSION: next
         POWERTOOLS_SERVICE_NAME: !Ref ServiceName
         POWERTOOLS_LOG_LEVEL: 'INFO'
         MAIN_CLASS: com.inventory.acl.FunctionConfiguration

--- a/src/java/template-inventory-ordering-service.yaml
+++ b/src/java/template-inventory-ordering-service.yaml
@@ -13,7 +13,7 @@ Transform:
       stackName: !Ref "AWS::StackName"
       apiKeySecretArn: !Ref DDApiKeySecretArn
       javaLayerVersion: "15"
-      extensionLayerVersion: "65"
+      extensionLayerVersion: "66"
       service: !Ref ServiceName
       env: !Ref Env
       version: !Ref CommitHash
@@ -48,6 +48,7 @@ Globals:
       Variables:
         ENV: !Ref Env
         DD_LOGS_INJECTION: "true"
+        DD_EXTENSION_VERSION: next
         POWERTOOLS_SERVICE_NAME: !Ref ServiceName
         POWERTOOLS_LOG_LEVEL: 'INFO'
         MAIN_CLASS: com.inventory.ordering.FunctionConfiguration

--- a/src/java/template-pricing-service.yaml
+++ b/src/java/template-pricing-service.yaml
@@ -12,7 +12,7 @@ Transform:
     Parameters:
       stackName: !Ref "AWS::StackName"
       apiKeySecretArn: !Ref DDApiKeySecretArn
-      extensionLayerVersion: "65"
+      extensionLayerVersion: "66"
       javaLayerVersion: "15"
       service: !Ref ServiceName
       env: !Ref Env
@@ -45,6 +45,7 @@ Globals:
       Variables:
         ENV: !Ref Env
         DD_LOGS_INJECTION: "true"
+        DD_EXTENSION_VERSION: next
         POWERTOOLS_SERVICE_NAME: !Ref ServiceName
         POWERTOOLS_LOG_LEVEL: 'INFO'
         MAIN_CLASS: com.product.pricing.FunctionConfiguration

--- a/src/java/template-product-api-worker.yaml
+++ b/src/java/template-product-api-worker.yaml
@@ -12,7 +12,7 @@ Transform:
     Parameters:
       stackName: !Ref "AWS::StackName"
       apiKeySecretArn: !Ref DDApiKeySecretArn
-      extensionLayerVersion: "65"
+      extensionLayerVersion: "66"
       javaLayerVersion: "15"
       service: !Ref ServiceName
       env: !Ref Env
@@ -48,6 +48,7 @@ Globals:
       Variables:
         ENV: !Ref Env
         DD_LOGS_INJECTION: "true"
+        DD_EXTENSION_VERSION: next
         POWERTOOLS_SERVICE_NAME: !Ref ServiceName
         POWERTOOLS_LOG_LEVEL: 'INFO'
         MAIN_CLASS: com.product.api.FunctionConfiguration

--- a/src/java/template-product-event-publisher.yaml
+++ b/src/java/template-product-event-publisher.yaml
@@ -12,7 +12,7 @@ Transform:
     Parameters:
       stackName: !Ref "AWS::StackName"
       apiKeySecretArn: !Ref DDApiKeySecretArn
-      extensionLayerVersion: "65"
+      extensionLayerVersion: "66"
       javaLayerVersion: "15"
       service: !Ref ServiceName
       env: !Ref Env
@@ -45,6 +45,7 @@ Globals:
       Variables:
         ENV: !Ref Env
         DD_LOGS_INJECTION: "true"
+        DD_EXTENSION_VERSION: next
         POWERTOOLS_SERVICE_NAME: !Ref ServiceName
         POWERTOOLS_LOG_LEVEL: 'INFO'
         MAIN_CLASS: com.product.publisher.FunctionConfiguration

--- a/src/nodejs/README.md
+++ b/src/nodejs/README.md
@@ -23,7 +23,7 @@ Once installed, you can use the Construct to configure all of your Datadog setti
 ```typescript
 const datadogConfiguration = new Datadog(this, "Datadog", {
   nodeLayerVersion: 115,
-  extensionLayerVersion: 65,
+  extensionLayerVersion: 66,
   site: process.env.DD_SITE,
   apiKeySecret: ddApiKey,
   service,

--- a/src/nodejs/README.md
+++ b/src/nodejs/README.md
@@ -164,7 +164,7 @@ module "aws_lambda_function" {
     var.environment_variables
   )
 
-  datadog_extension_layer_version = 65
+  datadog_extension_layer_version = 66
   datadog_node_layer_version      = 112
 }
 ```

--- a/src/nodejs/infra/modules/lambda-function/main.tf
+++ b/src/nodejs/infra/modules/lambda-function/main.tf
@@ -105,6 +105,6 @@ module "aws_lambda_function" {
     var.environment_variables
   )
 
-  datadog_extension_layer_version = 65
+  datadog_extension_layer_version = 66
   datadog_node_layer_version      = 115
 }

--- a/src/nodejs/lib/analytics-backend/analyticsBackendStack.ts
+++ b/src/nodejs/lib/analytics-backend/analyticsBackendStack.ts
@@ -30,7 +30,7 @@ export class AnalyticsBackendStack extends cdk.Stack {
 
     const datadogConfiguration = new Datadog(this, "Datadog", {
       nodeLayerVersion: 115,
-      extensionLayerVersion: 65,
+      extensionLayerVersion: 66,
       site: process.env.DD_SITE ?? "datadoghq.com",
       apiKeySecret: ddApiKey,
       service,

--- a/src/nodejs/lib/inventory-acl/inventoryAclStack.ts
+++ b/src/nodejs/lib/inventory-acl/inventoryAclStack.ts
@@ -30,7 +30,7 @@ export class InventoryAclStack extends cdk.Stack {
 
     const datadogConfiguration = new Datadog(this, "Datadog", {
       nodeLayerVersion: 115,
-      extensionLayerVersion: 65,
+      extensionLayerVersion: 66,
       site: process.env.DD_SITE ?? "datadoghq.com",
       apiKeySecret: ddApiKey,
       service,

--- a/src/nodejs/lib/inventory-ordering-service/inventoryOrderingServiceStack.ts
+++ b/src/nodejs/lib/inventory-ordering-service/inventoryOrderingServiceStack.ts
@@ -30,7 +30,7 @@ export class InventoryOrderServiceStack extends cdk.Stack {
 
     const datadogConfiguration = new Datadog(this, "Datadog", {
       nodeLayerVersion: 115,
-      extensionLayerVersion: 65,
+      extensionLayerVersion: 66,
       site: process.env.DD_SITE ?? "datadoghq.com",
       apiKeySecret: ddApiKey,
       service,

--- a/src/nodejs/lib/product-api-workers/product-api-worker-stack.ts
+++ b/src/nodejs/lib/product-api-workers/product-api-worker-stack.ts
@@ -31,7 +31,7 @@ export class ProductApiWorkerStack extends cdk.Stack {
 
     const datadogConfiguration = new Datadog(this, "Datadog", {
       nodeLayerVersion: 115,
-      extensionLayerVersion: 65,
+      extensionLayerVersion: 66,
       site: process.env.DD_SITE ?? "datadoghq.com",
       apiKeySecret: ddApiKey,
       service,

--- a/src/nodejs/lib/product-api/product-api-stack.ts
+++ b/src/nodejs/lib/product-api/product-api-stack.ts
@@ -30,7 +30,7 @@ export class ProductApiStack extends cdk.Stack {
 
     const datadogConfiguration = new Datadog(this, "Datadog", {
       nodeLayerVersion: 115,
-      extensionLayerVersion: 65,
+      extensionLayerVersion: 66,
       site: process.env.DD_SITE ?? "datadoghq.com",
       apiKeySecret: ddApiKey,
       service,

--- a/src/nodejs/lib/product-pricing/product-pricing-stack.ts
+++ b/src/nodejs/lib/product-pricing/product-pricing-stack.ts
@@ -31,7 +31,7 @@ export class ProductPricingStack extends cdk.Stack {
 
     const datadogConfiguration = new Datadog(this, "Datadog", {
       nodeLayerVersion: 115,
-      extensionLayerVersion: 65,
+      extensionLayerVersion: 66,
       site: process.env.DD_SITE ?? "datadoghq.com",
       apiKeySecret: ddApiKey,
       service,

--- a/src/nodejs/lib/product-public-event-publisher/product-public-event-publisher-stack.ts
+++ b/src/nodejs/lib/product-public-event-publisher/product-public-event-publisher-stack.ts
@@ -32,7 +32,7 @@ export class ProductPublicEventPublisherStack extends cdk.Stack {
 
     const datadogConfiguration = new Datadog(this, "Datadog", {
       nodeLayerVersion: 115,
-      extensionLayerVersion: 65,
+      extensionLayerVersion: 66,
       site: process.env.DD_SITE ?? "datadoghq.com",
       apiKeySecret: ddApiKey,
       service,

--- a/src/nodejs/template-analytics-service.yaml
+++ b/src/nodejs/template-analytics-service.yaml
@@ -13,7 +13,7 @@ Transform:
       stackName: !Ref "AWS::StackName"
       apiKeySecretArn: !Ref DDApiKeySecretArn
       nodeLayerVersion: "115"
-      extensionLayerVersion: "62"
+      extensionLayerVersion: "66"
       service: !Ref ServiceName
       env: !Ref Env
       version: !Ref CommitHash

--- a/src/nodejs/template-api.yaml
+++ b/src/nodejs/template-api.yaml
@@ -13,7 +13,7 @@ Transform:
       stackName: !Ref "AWS::StackName"
       apiKeySecretArn: !Ref DDApiKeySecretArn
       nodeLayerVersion: "115"
-      extensionLayerVersion: "62"
+      extensionLayerVersion: "66"
       service: !Ref ServiceName
       env: !Ref Env
       version: !Ref CommitHash

--- a/src/nodejs/template-inventory-acl.yaml
+++ b/src/nodejs/template-inventory-acl.yaml
@@ -13,7 +13,7 @@ Transform:
       stackName: !Ref "AWS::StackName"
       apiKeySecretArn: !Ref DDApiKeySecretArn
       nodeLayerVersion: "115"
-      extensionLayerVersion: "62"
+      extensionLayerVersion: "66"
       service: !Ref ServiceName
       env: !Ref Env
       version: !Ref CommitHash

--- a/src/nodejs/template-inventory-ordering-service.yaml
+++ b/src/nodejs/template-inventory-ordering-service.yaml
@@ -13,7 +13,7 @@ Transform:
       stackName: !Ref "AWS::StackName"
       apiKeySecretArn: !Ref DDApiKeySecretArn
       nodeLayerVersion: "115"
-      extensionLayerVersion: "62"
+      extensionLayerVersion: "66"
       service: !Ref ServiceName
       env: !Ref Env
       version: !Ref CommitHash

--- a/src/nodejs/template-pricing-service.yaml
+++ b/src/nodejs/template-pricing-service.yaml
@@ -13,7 +13,7 @@ Transform:
       stackName: !Ref "AWS::StackName"
       apiKeySecretArn: !Ref DDApiKeySecretArn
       nodeLayerVersion: "115"
-      extensionLayerVersion: "62"
+      extensionLayerVersion: "66"
       service: !Ref ServiceName
       env: !Ref Env
       version: !Ref CommitHash

--- a/src/nodejs/template-product-api-worker.yaml
+++ b/src/nodejs/template-product-api-worker.yaml
@@ -13,7 +13,7 @@ Transform:
       stackName: !Ref "AWS::StackName"
       apiKeySecretArn: !Ref DDApiKeySecretArn
       nodeLayerVersion: "115"
-      extensionLayerVersion: "62"
+      extensionLayerVersion: "66"
       service: !Ref ServiceName
       env: !Ref Env
       version: !Ref CommitHash

--- a/src/nodejs/template-product-event-publisher.yaml
+++ b/src/nodejs/template-product-event-publisher.yaml
@@ -13,7 +13,7 @@ Transform:
       stackName: !Ref "AWS::StackName"
       apiKeySecretArn: !Ref DDApiKeySecretArn
       nodeLayerVersion: "115"
-      extensionLayerVersion: "62"
+      extensionLayerVersion: "66"
       service: !Ref ServiceName
       env: !Ref Env
       version: !Ref CommitHash

--- a/src/rust/README.md
+++ b/src/rust/README.md
@@ -110,7 +110,7 @@ Globals:
     Timeout: 29
     MemorySize: 512
     Layers:
-      - !Sub arn:aws:lambda:${AWS::Region}:464622532012:layer:Datadog-Extension:65
+      - !Sub arn:aws:lambda:${AWS::Region}:464622532012:layer:Datadog-Extension:66
     Environment:
       Variables:
         ENV: !Ref Env
@@ -186,7 +186,7 @@ module "aws_lambda_function" {
     var.environment_variables
   )
 
-  datadog_extension_layer_version = 65
+  datadog_extension_layer_version = 66
 }
 ```
 

--- a/src/rust/README.md
+++ b/src/rust/README.md
@@ -39,7 +39,7 @@ Once installed, you can use the Construct to configure all of your Datadog setti
 ```typescript
 const datadogConfiguration = new Datadog(this, "Datadog", {
   nodeLayerVersion: 115,
-  extensionLayerVersion: 65,
+  extensionLayerVersion: 66,
   site: process.env.DD_SITE,
   apiKeySecret: ddApiKey,
   service,

--- a/src/rust/infra/modules/lambda-function/main.tf
+++ b/src/rust/infra/modules/lambda-function/main.tf
@@ -100,5 +100,5 @@ module "aws_lambda_function" {
     var.environment_variables
   )
 
-  datadog_extension_layer_version = 65
+  datadog_extension_layer_version = 66
 }

--- a/src/rust/lib/analytics-backend/analyticsBackendStack.ts
+++ b/src/rust/lib/analytics-backend/analyticsBackendStack.ts
@@ -29,7 +29,7 @@ export class AnalyticsBackendStack extends cdk.Stack {
     const version = process.env["COMMIT_HASH"] ?? "latest";
 
     const datadogConfiguration = new Datadog(this, "Datadog", {
-      extensionLayerVersion: 65,
+      extensionLayerVersion: 66,
       site: process.env.DD_SITE ?? "datadoghq.com",
       apiKeySecret: ddApiKey,
       service,

--- a/src/rust/lib/inventory-acl/inventoryAclStack.ts
+++ b/src/rust/lib/inventory-acl/inventoryAclStack.ts
@@ -29,7 +29,7 @@ export class InventoryAclStack extends cdk.Stack {
     const version = process.env["COMMIT_HASH"] ?? "latest";
 
     const datadogConfiguration = new Datadog(this, "Datadog", {
-      extensionLayerVersion: 65,
+      extensionLayerVersion: 66,
       site: process.env.DD_SITE ?? "datadoghq.com",
       apiKeySecret: ddApiKey,
       service,

--- a/src/rust/lib/inventory-ordering-service/inventoryOrderingServiceStack.ts
+++ b/src/rust/lib/inventory-ordering-service/inventoryOrderingServiceStack.ts
@@ -29,7 +29,7 @@ export class InventoryOrderServiceStack extends cdk.Stack {
     const version = process.env["COMMIT_HASH"] ?? "latest";
 
     const datadogConfiguration = new Datadog(this, "Datadog", {
-      extensionLayerVersion: 65,
+      extensionLayerVersion: 66,
       site: process.env.DD_SITE ?? "datadoghq.com",
       apiKeySecret: ddApiKey,
       service,

--- a/src/rust/lib/product-api-workers/product-api-worker-stack.ts
+++ b/src/rust/lib/product-api-workers/product-api-worker-stack.ts
@@ -30,7 +30,7 @@ export class ProductApiWorkerStack extends cdk.Stack {
     const version = process.env["COMMIT_HASH"] ?? "latest";
 
     const datadogConfiguration = new Datadog(this, "Datadog", {
-      extensionLayerVersion: 65,
+      extensionLayerVersion: 66,
       site: process.env.DD_SITE ?? "datadoghq.com",
       apiKeySecret: ddApiKey,
       service,

--- a/src/rust/lib/product-api/product-api-stack.ts
+++ b/src/rust/lib/product-api/product-api-stack.ts
@@ -29,7 +29,7 @@ export class ProductApiStack extends cdk.Stack {
     const version = process.env["COMMIT_HASH"] ?? "latest";
 
     const datadogConfiguration = new Datadog(this, "Datadog", {
-      extensionLayerVersion: 65,
+      extensionLayerVersion: 66,
       site: process.env.DD_SITE ?? "datadoghq.com",
       apiKeySecret: ddApiKey,
       service,

--- a/src/rust/lib/product-pricing/product-pricing-stack.ts
+++ b/src/rust/lib/product-pricing/product-pricing-stack.ts
@@ -30,7 +30,7 @@ export class ProductPricingStack extends cdk.Stack {
     const version = process.env["COMMIT_HASH"] ?? "latest";
 
     const datadogConfiguration = new Datadog(this, "Datadog", {
-      extensionLayerVersion: 65,
+      extensionLayerVersion: 66,
       site: process.env.DD_SITE ?? "datadoghq.com",
       apiKeySecret: ddApiKey,
       service,

--- a/src/rust/lib/product-public-event-publisher/product-public-event-publisher-stack.ts
+++ b/src/rust/lib/product-public-event-publisher/product-public-event-publisher-stack.ts
@@ -31,7 +31,7 @@ export class ProductPublicEventPublisherStack extends cdk.Stack {
     const version = process.env["COMMIT_HASH"] ?? "latest";
 
     const datadogConfiguration = new Datadog(this, "Datadog", {
-      extensionLayerVersion: 65,
+      extensionLayerVersion: 66,
       site: process.env.DD_SITE ?? "datadoghq.com",
       apiKeySecret: ddApiKey,
       service,

--- a/src/rust/template-analytics-service.yaml
+++ b/src/rust/template-analytics-service.yaml
@@ -13,7 +13,7 @@ Transform:
       stackName: !Ref "AWS::StackName"
       apiKeySecretArn: !Ref DDApiKeySecretArn
       rustLayerVersion: "115"
-      extensionLayerVersion: "65"
+      extensionLayerVersion: "66"
       service: !Ref ServiceName
       env: !Ref Env
       version: !Ref CommitHash

--- a/src/rust/template-api.yaml
+++ b/src/rust/template-api.yaml
@@ -32,7 +32,7 @@ Globals:
     Timeout: 29
     MemorySize: 512
     Layers:
-      - !Sub arn:aws:lambda:${AWS::Region}:464622532012:layer:Datadog-Extension:65
+      - !Sub arn:aws:lambda:${AWS::Region}:464622532012:layer:Datadog-Extension:66
     Environment:
       Variables:
         ENV: !Ref Env

--- a/src/rust/template-inventory-acl.yaml
+++ b/src/rust/template-inventory-acl.yaml
@@ -31,7 +31,7 @@ Globals:
     Timeout: 29
     MemorySize: 512
     Layers:
-      - !Sub arn:aws:lambda:${AWS::Region}:464622532012:layer:Datadog-Extension:65
+      - !Sub arn:aws:lambda:${AWS::Region}:464622532012:layer:Datadog-Extension:66
     Environment:
       Variables:
         ENV: !Ref Env

--- a/src/rust/template-inventory-ordering-service.yaml
+++ b/src/rust/template-inventory-ordering-service.yaml
@@ -34,7 +34,7 @@ Globals:
     Timeout: 29
     MemorySize: 512
     Layers:
-      - !Sub arn:aws:lambda:${AWS::Region}:464622532012:layer:Datadog-Extension:65
+      - !Sub arn:aws:lambda:${AWS::Region}:464622532012:layer:Datadog-Extension:66
     Environment:
       Variables:
         ENV: !Ref Env

--- a/src/rust/template-pricing-service.yaml
+++ b/src/rust/template-pricing-service.yaml
@@ -31,7 +31,7 @@ Globals:
     Timeout: 29
     MemorySize: 512
     Layers:
-      - !Sub arn:aws:lambda:${AWS::Region}:464622532012:layer:Datadog-Extension:65
+      - !Sub arn:aws:lambda:${AWS::Region}:464622532012:layer:Datadog-Extension:66
     Environment:
       Variables:
         ENV: !Ref Env

--- a/src/rust/template-product-api-worker.yaml
+++ b/src/rust/template-product-api-worker.yaml
@@ -34,7 +34,7 @@ Globals:
     Timeout: 29
     MemorySize: 512
     Layers:
-      - !Sub arn:aws:lambda:${AWS::Region}:464622532012:layer:Datadog-Extension:65
+      - !Sub arn:aws:lambda:${AWS::Region}:464622532012:layer:Datadog-Extension:66
     Environment:
       Variables:
         ENV: !Ref Env

--- a/src/rust/template-product-event-publisher.yaml
+++ b/src/rust/template-product-event-publisher.yaml
@@ -31,7 +31,7 @@ Globals:
     Timeout: 29
     MemorySize: 512
     Layers:
-      - !Sub arn:aws:lambda:${AWS::Region}:464622532012:layer:Datadog-Extension:65
+      - !Sub arn:aws:lambda:${AWS::Region}:464622532012:layer:Datadog-Extension:66
     Environment:
       Variables:
         ENV: !Ref Env


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/serverless-sample-app/blob/main/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?

- Updates the Datadog Extension layer to `v66`.
- Also enables the next gen extension for .NET and Java

### Motivation

New features in the Next Gen extension

### Testing Guidelines

<!--- How did you test this pull request? --->

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of Changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [ ] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
