### PR TITLE
chore: re-enable dependabot with 2-day cooldown

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,6 +10,8 @@ updates:
         patterns:
           - "*"
 
+    cooldown:
+      default-days: 2
   - package-ecosystem: "npm"
     directories:
       - "/src/loyalty-point-service"
@@ -22,6 +24,8 @@ updates:
         patterns:
           - "*"
 
+    cooldown:
+      default-days: 2
   - package-ecosystem: "nuget"
     directory: "/src/order-service"
     schedule:
@@ -31,6 +35,8 @@ updates:
         patterns:
           - "*"
 
+    cooldown:
+      default-days: 2
   - package-ecosystem: "terraform"
     directories:
       - "/src/inventory-service/infra"
@@ -47,6 +53,8 @@ updates:
         patterns:
           - "*"
 
+    cooldown:
+      default-days: 2
   - package-ecosystem: "cargo"
     directories:
       - "/src/user-management-service"
@@ -57,6 +65,8 @@ updates:
         patterns:
           - "*"
 
+    cooldown:
+      default-days: 2
   - package-ecosystem: "pip"
     directories:
       - "/src/activity-service"
@@ -65,4 +75,5 @@ updates:
     groups:
       python-dependencies:
         patterns:
-          - "*"
+          - "*"    cooldown:
+      default-days: 2


### PR DESCRIPTION
> [!NOTE]
> **Merge only if this is still needed and your repo is not managed by ADMS.**
> If your repository is already managed by ADMS, feel free to close or ignore this PR.

---

We are adding a 2-day cooldown on dependencies to reduce the risk of zero-day vulnerabilities.

This PR re-enables your Dependabot configuration and introduces the cooldown setting. If you notice any other Dependabot configurations in your repo that are missing the cooldown, please ensure it is added.

If your repository is already managed by ADMS and no longer requires these configurations, feel free to close or ignore the PR.